### PR TITLE
Add sandshrew to its own setup.py's packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name = "sandshrew",
     version = "0.0.1",
+    packages = ['sandshrew'],
     url="https://github.com/trailofbits/sandshrew",
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
This fixes an issue with installation where Python/setuptools can't find
the correct module to run the main function from.